### PR TITLE
Replace sudo command with become

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Install xDebug
-  sudo: yes
+  become: yes
   apt: pkg=php5-xdebug state=latest
 
 - name: Apply xDebug settings
-  sudo: true
+  become: yes
   lineinfile: dest=/etc/php5/mods-available/xdebug.ini
               regexp='^;?{{ item.key }}'
               line='{{ item.key }}={{ item.value }}'


### PR DESCRIPTION
Issue: [phansible/phansible/issues/273](https://github.com/phansible/phansible/issues/273)
Replace `sudo` command `become`since `sudo` will be deprecated.
